### PR TITLE
"throw" errors instead of trying to "raise" them

### DIFF
--- a/docopt.coffee
+++ b/docopt.coffee
@@ -336,7 +336,7 @@ parse_pattern = (source, options) ->
                          DocoptLanguageError
     result = parse_expr tokens, options
     if tokens.current() is not null
-        raise tokens.error 'unexpected ending: ' + tokens.join ' '
+        throw tokens.error 'unexpected ending: ' + tokens.join ' '
     new Required result
 
 
@@ -380,7 +380,7 @@ parse_atom = (tokens, options) ->
 
         result = [new Required parse_expr tokens, options]
         if tokens.shift() != ')'
-            raise tokens.error "Unmatched '('"
+            throw tokens.error "Unmatched '('"
         result
     else if token is '['
         tokens.shift()
@@ -390,7 +390,7 @@ parse_atom = (tokens, options) ->
         else
             result = [new Optional parse_expr tokens, options]
         if tokens.shift() != ']'
-            raise tokens.error "Unmatched '['"
+            throw tokens.error "Unmatched '['"
         result
     else if token[0..1] is '--'
         if token is '--'

--- a/docopt.js
+++ b/docopt.js
@@ -699,7 +699,7 @@
     tokens = new TokenStream(source.replace(/([\[\]\(\)\|]|\.\.\.)/g, ' $1 '), DocoptLanguageError);
     result = parse_expr(tokens, options);
     if (tokens.current() === !null) {
-      raise(tokens.error('unexpected ending: ' + tokens.join(' ')));
+      throw tokens.error('unexpected ending: ' + tokens.join(' '));
     }
     return new Required(result);
   };
@@ -745,7 +745,7 @@
       tokens.shift();
       result = [new Required(parse_expr(tokens, options))];
       if (tokens.shift() !== ')') {
-        raise(tokens.error("Unmatched '('"));
+        throw tokens.error("Unmatched '('");
       }
       return result;
     } else if (token === '[') {
@@ -757,7 +757,7 @@
         result = [new Optional(parse_expr(tokens, options))];
       }
       if (tokens.shift() !== ']') {
-        raise(tokens.error("Unmatched '['"));
+        throw tokens.error("Unmatched '['");
       }
       return result;
     } else if (token.slice(0, 2) === '--') {


### PR DESCRIPTION
The Coffee Script port says `raise` when it means `throw`, the valid ECMAScript keyword for error-raising statements. I'm guessing the test suite checks only that an error is raised, but what it's actually detecting is the not-defined error for `raise` itself.

The diff was longer than I expected when I re-compiled with the most recent Coffee Script, so I edited the `.js` by hand instead.
